### PR TITLE
forgot to uncomment, Makefile correction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ download: $(FLIGHTS) $(foreach f,$(shell mc ls dc24/competition-data  | rev | cu
 
 cleantrajectories: $(TRAJS)
 
-features: $(CRUISES) $(MASSES) $(WINDS)
-# $(WEATHERS) $(THUNDERS)
+features: $(CRUISES) $(MASSES) $(WINDS) $(WEATHERS) $(THUNDERS)
 #$(WEATHERS) $(THUNDERS) $(WINDS)
 
 submissions:


### PR DESCRIPTION
Dear Enrico,

I reruned  my whole code from scratch just to be sure that everything went ok with just the Makefile command starting from scratch. This made me realized that I forgot to uncomment METAR related features creation. So to reproduce the results, one must correct this Makefile's line.

Best regards,
Richard